### PR TITLE
Add support for darwin/arm64 builds

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -73,6 +73,8 @@ jobs:
             EXT: .exe
         exclude:
           - OS: darwin
+            ARCH: 386
+          - OS: darwin
             ARCH: arm
           - OS: windows
             ARCH: arm64

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -73,8 +73,6 @@ jobs:
             EXT: .exe
         exclude:
           - OS: darwin
-            ARCH: arm64
-          - OS: darwin
             ARCH: arm
           - OS: windows
             ARCH: arm64


### PR DESCRIPTION
Removed `darwin/arm64` from exclusions to add support for M1 Macs.


