### PR TITLE
build(krew): add arm64 binaries to index

### DIFF
--- a/krew/krew.tpl
+++ b/krew/krew.tpl
@@ -21,6 +21,19 @@ spec:
     - selector:
         matchLabels:
           os: darwin
+          arch: arm64
+      uri: https://github.com/chrisns/kubectl-passman/releases/download/{{env "VERSION"}}/kubectl-passman-darwin-arm64.zip
+      sha256: "{{.kubectl_passman_darwin_arm64}}"
+      bin: "./kubectl-passman"
+      files:
+        - from: kubectl-passman-darwin-arm64
+          to: kubectl-passman
+        - from: LICENSE
+          to: .
+
+    - selector:
+        matchLabels:
+          os: darwin
           arch: 386
       uri: https://github.com/chrisns/kubectl-passman/releases/download/{{env "VERSION"}}/kubectl-passman-darwin-386.zip
       sha256: "{{.kubectl_passman_darwin_386}}"
@@ -40,6 +53,19 @@ spec:
       bin: "./kubectl-passman"
       files:
         - from: kubectl-passman-linux-arm
+          to: kubectl-passman
+        - from: LICENSE
+          to: .
+
+    - selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      uri: https://github.com/chrisns/kubectl-passman/releases/download/{{env "VERSION"}}/kubectl-passman-linux-arm64.zip
+      sha256: "{{.kubectl_passman_linux_arm64}}"
+      bin: "./kubectl-passman"
+      files:
+        - from: kubectl-passman-linux-arm64
           to: kubectl-passman
         - from: LICENSE
           to: .


### PR DESCRIPTION
arm64 binaries were missing when trying to install via `kubectl krew install passman`.

This PR should fix that. I had a look at the `generate-shas.sh` and it seems like the shasums for those zip files should be passed into the template already?

edit: Just noticed that the commit message is wrong, sorry about that - it's arm64