### PR TITLE
Fix executable name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Then add it to the `~/.kube/config`:
 kubectl config set-credentials \
   kubectl-prod-user \
  --exec-api-version=client.authentication.k8s.io/v1beta1 \
- --exec-command=passman \
+ --exec-command=kubectl-passman \
  --exec-arg=keychain \ # or 1password
  --exec-arg=kubectl-prod-user # name of [item-name] you used when you wrote to the password manager
 ```


### PR DESCRIPTION
Please correct me if I'm doing something wrong, but...

After installing kubectl-passman via krew and setting the user credential `exec` config according to the README, I get an error that the command `passman` is not found:
```
$ kubectl get nodes
Unable to connect to the server: getting credentials: exec: executable passman not found

It looks like you are trying to use a client-go credential plugin that is not installed.

To learn more about this feature, consult the documentation available at:
      https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins
```
The executable in my `$PATH` is `kubectl-passman` and not `passman`. If I update the command to `kubectl-passman`, everything works as expected.