### PR TITLE
Remove default my-bearer-token

### DIFF
--- a/app.go
+++ b/app.go
@@ -126,7 +126,7 @@ func read(handler, itemName string) error {
 }
 
 type responseStatus struct {
-	Token                  string `default:"my-bearer-token" json:"token,omitempty"`
+	Token                  string `json:"token,omitempty"`
 	ClientCertificateData  string `json:"clientCertificateData,omitempty"`
 	ClientCertificateDataD string `json:"client-certificate-data,omitempty"`
 	ClientKeyData          string `json:"clientKeyData,omitempty"`


### PR DESCRIPTION
The default "my-bearer-token" is corresponding to nothing, leading issues in python-kubernetes and derivated tools (krr)

The documentation (https://kubernetes.io/docs/reference/access-authn-authz/authentication/#input-and-output-formatsà
doesn't provide any token entry if certificate/key is provided